### PR TITLE
feat: add php-pcntl

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -7,7 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache icu-data-full curl jq && \
     apk upgrade --no-cache && \
     chmod +x /usr/local/bin/install-php-extensions && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
     mkdir -p /var/www/html && \
     mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" && \
     rm -f /usr/local/etc/php-fpm.d/zz-docker.conf && \

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -7,7 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache icu-data-full curl jq && \
     apk upgrade --no-cache && \
     chmod +x /usr/local/bin/install-php-extensions && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
     mkdir -p /var/www/html && \
     mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" && \
     rm -f /usr/local/etc/php-fpm.d/zz-docker.conf && \

--- a/8.2/Dockerfile
+++ b/8.2/Dockerfile
@@ -7,7 +7,7 @@ ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/do
 RUN apk add --no-cache icu-data-full curl jq && \
     apk upgrade --no-cache && \
     chmod +x /usr/local/bin/install-php-extensions && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql pcntl sockets bz2 gmp soap zip ffi redis opcache apcu amqp && \
     mkdir -p /var/www/html && \
     mv "${PHP_INI_DIR}/php.ini-production" "${PHP_INI_DIR}/php.ini" && \
     rm -f /usr/local/etc/php-fpm.d/zz-docker.conf && \


### PR DESCRIPTION
Symfony messenger needs SIGTERM & SIGINT commands to work properly: https://github.com/symfony/messenger/blob/641bde9896f8f4399426a65a0925c09d05519bfa/Command/ConsumeMessagesCommand.php#L261C32-L261C32

This is included in https://www.php.net/manual/de/book.pcntl.php which is not part of the current docker build. It can be verified using:

`php -i | grep pcntl`

This PR adds pcntl to all PHP versions