### PR TITLE
nginx - remove (dot) location rule

### DIFF
--- a/nginx/rootfs/etc/nginx/nginx.conf
+++ b/nginx/rootfs/etc/nginx/nginx.conf
@@ -42,11 +42,6 @@ http {
         root   /var/www/html/public;
         index  index.php;
         include /etc/nginx/mime.types;
-
-        # Deny access to . (dot) files
-        location ~ /\. {
-            deny all;
-        }
     
         # Deny access to .php files in public directories
         location ~ ^/(media|thumbnail|theme|bundles|sitemap).*\.php$ {


### PR DESCRIPTION
This allows placing files under `.well-known` url - resolve #148 