### PR TITLE
fix(setup): execute deployment helper

### DIFF
--- a/fpm/rootfs/setup
+++ b/fpm/rootfs/setup
@@ -4,7 +4,7 @@ set -e
 
 cd /var/www/html
 
-if [[ -e /var/www/html/vendor/bin/shopware-deployment-helper ]]; then
+if [ -x ./vendor/bin/shopware-deployment-helper ]; then
     exec ./vendor/bin/shopware-deployment-helper run
 fi
 

--- a/frankenphp/rootfs/setup
+++ b/frankenphp/rootfs/setup
@@ -4,7 +4,7 @@ set -e
 
 cd /var/www/html
 
-if [[ -e /var/www/html/vendor/bin/shopware-deployment-helper ]]; then
+if [ -x ./vendor/bin/shopware-deployment-helper ]; then
     exec ./vendor/bin/shopware-deployment-helper run
 fi
 


### PR DESCRIPTION
`[[` is not a valid command, but a bash builtin.
The `setup` file itself defines `sh` as the interpreter to use. This is not available using `sh` and results in "[[: not found".

From `man [`:

       -x FILE
              FILE exists and the user has execute (or search) access