### PR TITLE
feat: add SPX PHP extension to dev image

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -29,13 +29,14 @@ RUN <<EOF
 
     apk add --no-cache bash git shadow patch coreutils
     
-    install-php-extensions tideways blackfire xdebug/xdebug@3.5.0
+    install-php-extensions tideways blackfire xdebug/xdebug@3.5.0 spx
 
     cd /usr/local/etc/php/conf.d
     mv docker-php-ext-opentelemetry.ini docker-php-ext-opentelemetry.disabled
     mv docker-php-ext-xdebug.ini docker-php-ext-xdebug.disabled
     mv docker-php-ext-tideways.ini docker-php-ext-tideways.disabled
     mv docker-php-ext-blackfire.ini docker-php-ext-blackfire.disabled
+    mv docker-php-ext-spx.ini docker-php-ext-spx.disabled
 
     usermod -u 1000 www-data
     groupmod -g 1000 www-data

--- a/dev/config.yaml
+++ b/dev/config.yaml
@@ -19,6 +19,7 @@ commandTests:
       - 'opentelemetry'
       - 'tideways'
       - 'blackfire'
+      - 'spx'
   - name: "PHP dev extensions disabled by default"
     command: "sh"
     args: ["-c", "ls /usr/local/etc/php/conf.d/*.disabled"]
@@ -27,6 +28,7 @@ commandTests:
       - 'docker-php-ext-tideways.disabled'
       - 'docker-php-ext-blackfire.disabled'
       - 'docker-php-ext-opentelemetry.disabled'
+      - 'docker-php-ext-spx.disabled'
   - name: "Node installed"
     command: 'node'
     args: ["-v"]


### PR DESCRIPTION
## Summary
- Add SPX PHP profiler extension to the dev Dockerfile via `install-php-extensions`
- Disable SPX by default (`docker-php-ext-spx.ini` → `docker-php-ext-spx.disabled`), consistent with Xdebug, Tideways, and Blackfire
- Add SPX to container-structure-test assertions for both installed and disabled states

## Test plan
- [ ] Verify `docker build` succeeds for the dev image
- [ ] Confirm SPX is installed: `docker run <image> php -m | grep spx`
- [ ] Confirm SPX is disabled by default: check for `docker-php-ext-spx.disabled` in `/usr/local/etc/php/conf.d/`