### PR TITLE
ci: fix trivy scan alerts not resolving by setting SARIF category per image

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,3 +59,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: ${{ matrix.php-version }}-${{ matrix.variant.name }}


### PR DESCRIPTION
## Problem

The security workflow runs trivy scans across a matrix of 4 PHP versions x 8 image variants (32 jobs), and every job uploaded its SARIF with no `category` set. GitHub groups code-scanning analyses by `(tool, category, ref)`, so all 32 uploads shared one analysis — the last job to finish became the "current" one. On every nightly run, alerts from all other images got resolved and then reopened, producing constant churn and alerts that never stayed fixed (1,296 stale open alerts accumulated).

## Fix

Set a unique `category` per matrix combination (`php-version-variant`) in the `upload-sarif` step, so each image has its own analysis and its alerts auto-resolve once the vulnerability is actually gone from the published image.

## Note

The existing open alerts were created under the old empty category and are orphaned — they have been bulk-closed manually. Alerts for CVEs still present in the current images will be re-reported by the next scan, this time under the correct category.